### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ npm run watch
 
 To use with Claude Desktop, add the server configuration:
 
-On MacOS: `~/Library/Application Support/Claude/claude_desktop_config.json`  
+On MacOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
 On Windows: `%APPDATA%/Claude/claude_desktop_config.json`
 
 ```json

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol server that provides read-only access to MongoDB databases through standardized MCP tools and resources.
 
+<a href="https://glama.ai/mcp/servers/cmywezu1sn">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/cmywezu1sn/badge" alt="MongoDB Server MCP server" />
+</a>
+
 ## Overview
 
 This MongoDB MCP server enables AI assistants to directly query and analyze MongoDB databases without write access, maintaining data safety while providing powerful data exploration capabilities.
@@ -61,7 +65,7 @@ npm run watch
 
 To use with Claude Desktop, add the server configuration:
 
-On MacOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+On MacOS: `~/Library/Application Support/Claude/claude_desktop_config.json`  
 On Windows: `%APPDATA%/Claude/claude_desktop_config.json`
 
 ```json


### PR DESCRIPTION
This PR adds a badge for the [MongoDB MCP Server](https://glama.ai/mcp/servers/cmywezu1sn) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/cmywezu1sn">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/cmywezu1sn/badge" alt="MongoDB Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.