### PR TITLE
Remove $addFields from list of unsafe aggregation operations.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -466,13 +466,14 @@ Supported Stages:
 - $group: Group documents by a key
 - $sort: Sort documents
 - $project: Shape the output
+- $addFields - Include additional or calculated fields
 - $lookup: Perform left outer joins
 - $unwind: Deconstruct array fields
+
 
 Unsafe/Blocked Stages:
 - $out: Write results to collection
 - $merge: Merge results into collection
-- $addFields: Add new fields
 - $set: Set field values
 - $unset: Remove fields
 - $replaceRoot: Replace document structure

--- a/src/index.ts
+++ b/src/index.ts
@@ -173,7 +173,7 @@ Error Handling:
       );
     }
 
-    const unsafeStages = ['$out', '$merge', '$addFields', '$set', '$unset', '$replaceRoot', '$replaceWith'];
+    const unsafeStages = ['$out', '$merge', '$set', '$unset', '$replaceRoot', '$replaceWith'];
     const unsafeStageFound = pipeline.find(stage => 
       Object.keys(stage).some(key => unsafeStages.includes(key))
     );


### PR DESCRIPTION
I was surprised to see $addFields in the list, as it does not modify any data in the database, but instead acts as a $project+, projecting all current fields to the next stage, plus any additional fields you might want to add (like a calculated field). Thus it can do no harm to the database, it can only modify the next stage in the pipeline, just as a $project would do. 